### PR TITLE
add project name as prompt when running script

### DIFF
--- a/yara
+++ b/yara
@@ -4,10 +4,21 @@ echo "Starting Yara Yara: A TS Node Express Quick Start Script."
 
 sleep 2
 
-echo "Creating TypeScript Node Server and all folder structure.."
+# Prompt for project name
+read -p "Enter project name (required): " projectName
 
-# Create source folder and its subfolders
-mkdir -p src/controllers src/database src/interfaces src/middlewares src/routes src/services src/utils
+# Validate project name input
+if [ -z "$projectName" ]; then
+    projectName="node-ts-starter" # Fixed the '-' before variable assignment
+fi
+
+# Convert project name to lowercase with hyphens
+projectFolder=$(echo "$projectName" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
+echo "Creating project folder '$projectFolder' and all folder structure.."
+
+# Create project folder and its subfolders
+mkdir -p "$projectFolder/src/controllers" "$projectFolder/src/database" "$projectFolder/src/interfaces" "$projectFolder/src/middlewares" "$projectFolder/src/routes" "$projectFolder/src/services" "$projectFolder/src/utils"
 
 sleep 2
 
@@ -15,23 +26,13 @@ echo "Folder structure created successfully."
 
 sleep 2
 
-echo "Creating files.."
+echo "Creating files in '$projectFolder'.."
 
 # Create source files
-touch src/controllers/greeting.controller.ts
-touch src/database/greeting.model.ts
-touch src/routes/greeting.route.ts
-touch src/middlewares/index.ts
-touch src/services/greeting.service.ts
-touch src/utils/helpers.ts
-touch src/swagger.ts
-touch src/server.ts
-touch src/app.ts
+touch "$projectFolder/src/controllers/greeting.controller.ts" "$projectFolder/src/database/greeting.model.ts" "$projectFolder/src/routes/greeting.route.ts" "$projectFolder/src/middlewares/index.ts" "$projectFolder/src/services/greeting.service.ts" "$projectFolder/src/utils/helpers.ts" "$projectFolder/src/swagger.ts" "$projectFolder/src/server.ts" "$projectFolder/src/app.ts"
 
 # Create other files
-touch .env
-touch .gitignore
-touch package.json
+touch "$projectFolder/.env" "$projectFolder/.gitignore" "$projectFolder/package.json"
 
 echo "Files created successfully."
 
@@ -40,43 +41,15 @@ sleep 2
 echo "Adding details to files.."
 
 # Add details to .env file
-echo "PORT=3000" > .env
-
-# add this to package.json
-cat <<EOF > package.json
-{
-  "name": "node-typescript-starter",
-  "version": "1.0.0",
-  "description": "A starter project for Node.js with TypeScript",
-  "main": "app.js",
-  "scripts": {
-    "start:dev": "ts-node-dev --respawn --transpile-only ./src/app",
-    "start": "node ./build/app.js"
-  },
-  "keywords": [
-	"node",
-	"typescript"
-  ],
-  "author": "HighB33Kay",
-  "license": "MIT",
-  "dependencies": {
-  },
-  "devDependencies": {
-  },
-  "engines": {
-    "node": ">=14.0.0"
-  }
-} 
-EOF
+echo "PORT=3000" > "$projectFolder/.env"
 
 # Add details to README.md in src directory
-echo "# Source Folder" > src/README.md
-echo "This folder contains the source code for the project." >> src/README.md
-echo "Please refer to individual subfolders for specific details." >> src/README.md
+echo "# Source Folder" > "$projectFolder/src/README.md"
+echo "This folder contains the source code for the project." >> "$projectFolder/src/README.md"
+echo "Please refer to individual subfolders for specific details." >> "$projectFolder/src/README.md"
 
-# add folder structure to README.md in root directory
-cat <<EOF > README.md
-# Node.js with TypeScript Starter
+# Add folder structure to README.md in root directory
+echo "# Node.js with TypeScript Starter
 
 This is a starter project for Node.js with TypeScript.
 
@@ -99,6 +72,7 @@ This is a starter project for Node.js with TypeScript.
 |--- package.json
 |--- tsconfig.json
 \`\`\`
+
 ## Dependencies
 
 - Node.js
@@ -113,14 +87,14 @@ This is a starter project for Node.js with TypeScript.
 - Run \`npm run start\` to start the production server
 - Visit \`http://localhost:3000/api/v1/greetings\` to see the result
 
-EOF
+" > "$projectFolder/README.md"
 
 # Create index.ts files in each subfolder to export modules
-echo "export * from './greeting.controller';" > src/controllers/index.ts
-echo "export * from './greeting.route';" > src/interfaces/index.ts
-echo "export * from './index';" > src/middlewares/index.ts
-echo "export * from './greeting.service';" > src/services/index.ts
-echo "export * from './helpers';" > src/utils/index.ts
+echo "export * from './greeting.controller';" > "$projectFolder/src/controllers/index.ts"
+echo "export * from './greeting.route';" > "$projectFolder/src/interfaces/index.ts"
+echo "export * from './index';" > "$projectFolder/src/middlewares/index.ts"
+echo "export * from './greeting.service';" > "$projectFolder/src/services/index.ts"
+echo "export * from './helpers';" > "$projectFolder/src/utils/index.ts"
 
 echo "Adding details to files successfully.."
 
@@ -128,23 +102,39 @@ sleep 2
 
 echo "Installing dependencies.."
 
-# Create package.json file
 # Initialize Node.js project
-npm init -y
+cd "$projectFolder" || exit
+
+# Create package.json file
+cat <<EOF > "./package.json"
+{
+  "name": "$projectName",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start:dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "start": "node build/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}
+EOF
 
 # Install TypeScript and type definitions for Node.js
 npm install typescript @types/node --save-dev
 
-# install ts-node-dev and type definitions for it
+# Install ts-node-dev and type definitions for it
 npm install ts-node-dev --save-dev
 
-# initialize TypeScript project
+# Initialize TypeScript project
 npx tsc --init
 
 # rm tsconfig.json
 rm tsconfig.json
 
-# remove everything from tsconfig.json file and add the following
+# Remove everything from tsconfig.json file and add the following
 cat <<EOF > tsconfig.json
 {
   "compilerOptions": {
@@ -158,26 +148,25 @@ cat <<EOF > tsconfig.json
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true
-    // "typeRoots": ["node_modules/@types"],
-    // "types": ["node", "express", "body-parser"]
+    // "typeRoots": ["node_modules/@types
   }
 }
 EOF
 
-# install express and type definitions for express
+# Install express and type definitions for express
 npm install express @types/express --save
 
-# install swagger, swagger ui, swagger jsdoc and type definitions for them
+# Install swagger, swagger ui, swagger jsdoc and type definitions for them
 npm install swagger-ui-express swagger-jsdoc @types/swagger-ui-express @types/swagger-jsdoc --save
 
-# install morgan and type definitions for it
+# Install morgan and type definitions for it
 npm install morgan @types/morgan --save
 
-# create swagger.ts file
-touch src/swagger.ts
+# Create swagger.ts file
+touch "./src/swagger.ts"
 
-# add the following to swagger.ts file
-cat <<EOF > src/swagger.ts
+# Add the following to swagger.ts file
+cat <<EOF > "./src/swagger.ts"
 import swaggerJsdoc from "swagger-jsdoc";
 
 const options = {
@@ -231,19 +220,19 @@ sleep 2
 
 echo "Setting up greetings API.."
 
-# create controllers
+# Create controllers
 echo "import { Request, Response } from 'express';
 
 export function getGreetings(req: Request, res: Response) {
   res.json({ message: 'Hello World!🌍' });
-}" > src/controllers/greeting.controller.ts
+}" > "./src/controllers/greeting.controller.ts"
 
-# create services
+# Create services
 echo "export async function getAllGreetings() {
   return [];
-}" > src/services/greeting.service.ts
+}" > "./src/services/greeting.service.ts"
 
-# create routes
+# Create routes
 echo "import { Router } from 'express';
 
 /**
@@ -275,10 +264,11 @@ const router = Router();
 
 router.get('/greetings', getGreetings);
 
-module.exports = router;" > src/routes/greeting.route.ts
+module.exports = router;" > "./src/routes/greeting.route.ts"
 
-# create app.ts file
+# Create app.ts file
 echo "import express from 'express';
+require('dotenv').config();
 import { readdirSync } from 'fs';
 import { join } from 'path';
 import morgan from 'morgan';
@@ -287,60 +277,60 @@ const swaggerUi = require('swagger-ui-express');
 const swaggerOptions = require('./swagger');
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 app.use(morgan('dev'));
 
-//  Swagger UI
+// Swagger UI
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerOptions));
 
 // Dynamically serve all routes
 readdirSync('./src/routes').map((path) => {
-    app.use('/api/v1/', require(\`./routes/\${path}\`));
+    app.use('/api/v1/', require(\`./routes\${path}\`));
 });
 
 app.listen(port, () => {
   console.log(\`Server is running on port \${port}\`);
-});" > src/app.ts
+});" > "./src/app.ts"
 
 echo "Setting up greetings API successfully."
 
 sleep 2
 
-echo "TypeScript Node Server and all folder structure has been created successfully."
+echo "TypeScript Node Server and all folder structure have been created successfully in '$projectFolder'."
 
 echo "Running the server.."
 
-# if the server has git initialized, then push to git
-if [ -d ".git" ]; then
-	echo "Git is initialized."
+# If the server has git initialized, then push to git
+if [ -d ".//.git" ]; then
+    echo "Git is initialized."
 
-	# check if remote is set
-	if [ -z "$(git remote show origin)" ]; then
-		echo "Remote is not set."
-		echo "Please set the remote to sync."
-	fi
+    # Check if remote is set
+    if [ -z "$(git -C "./" remote show origin)" ]; then
+        echo "Remote is not set."
+        echo "Please set the remote to sync."
+    fi
 else
-	echo "Git is not initialized."
-	echo "Initializing git.."
-	git init
-	echo "Git initialized successfully."
+    echo "Git is not initialized."
+    echo "Initializing git in '$projectFolder'.."
+    git -C "./" init
+    echo "Git initialized successfully in '$projectFolder'."
 fi
 
 echo "Adding git ignore.."
 
-# pull node ts git ignore
-curl https://raw.githubusercontent.com/github/gitignore/master/Node.gitignore --output .gitignore	
+# Pull node ts git ignore
+curl https://raw.githubusercontent.com/github/gitignore/master/Node.gitignore --output "$./.gitignore"	
 
 echo "Pushing to git.."
 
-# push to git
-git add .
-git commit -m "Initial commit"
+# Push to git
+git -C "./" add .
+git -C "./" commit -m "Initial commit"
 
-if git remote show origin > /dev/null 2>&1; then
-    git push
-	echo "Pushed to git successfully."
+if git -C "./" remote show origin > /dev/null 2>&1; then
+    git -C "./" push
+    echo "Pushed to git successfully."
 else
     echo "Remote is not set."
     echo "Please set the remote to sync."
@@ -350,5 +340,5 @@ sleep 2
 
 echo "Running the server.."
 
-# run the server and check if it works
+# Run the server and check if it works
 npm run start:dev


### PR DESCRIPTION
Hey man! Great job here.

As a "lazy" person myself, I find this to be a helpful tool. I had a different scenario in mind when attempting to use this tool. From my observation, it seems the "yara" file has to be in the project folder before it is run as it will create the folders in the current directory. What this also means is that I need always to have this file duplicated and deleted with each use. So I thought of a scenario where this file exists in a parent directory. When I run the shell command, I need to specify the name of the project I am trying to initiate (this can be later improved to take a path as an argument). With this, the shell creates the folder name which I specify and also uses it in the package.json file and other relevant places. 

Do take a look and let me know what you think